### PR TITLE
Recast README coding as coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Dependencies:
     xarray (optional but recommended)
 
 Useage example to get started:
+
     >from MDSmonkey import MDSmonkey as mm
     >tree = mm.get_tree('efit01', 134020) #mdsplus tree type returned
     >tree  #hit <Return> to print attribute list, or tab-complete in ipython

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dependencies:
     MDSplus
     xarray (optional but recommended)
 
-Useage example to get started:
+Usage example to get started:
 
     >from MDSmonkey import MDSmonkey as mm
     >tree = mm.get_tree('efit01', 134020) #mdsplus tree type returned


### PR DESCRIPTION
@lamorton Without the extra space, your coding was being strung into a single line.